### PR TITLE
fix: added chmod +x to conkyd script in the installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Clone the repo to a desired location and run conky on all the overlays. You can 
 
 ```
 git clone https://github.com/AyoItsYas/Mainte.git
-mkdir -p ~/.config/.conky/
-mv ./Mainte/ ~/.config/.conky/
+mkdir -p ~/.conky/
+mv ./Mainte/ ~/.conky/
 
 curl https://raw.githubusercontent.com/AyoItsYas/bin/main/conkyd > conkyd
 chmod +x conkyd

--- a/README.md
+++ b/README.md
@@ -19,5 +19,6 @@ mkdir -p ~/.config/.conky/
 mv ./Mainte/ ~/.config/.conky/
 
 curl https://raw.githubusercontent.com/AyoItsYas/bin/main/conkyd > conkyd
+chmod +x conkyd
 ./conkyd start
 ```


### PR DESCRIPTION
During installation, without the chmod, the script would fail with an inadequate permissions error. Fixed it with adding the `chmod +x conkyd` step. 